### PR TITLE
Tt 4549 add ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.apk
 *.ap_
 
+# Security
+*.p12
+
 # Files for the ART/Dalvik VM
 *.dex
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 [TT-4514] - Initial port of Quickets
+[TT-4549] - Add profile to enable SSL

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ the following command.
 java -DQUICK_PRINT_API_KEY=123  -jar build/libs/quickprint-{version}.jar
 ```
 
+#### Enabling SSL 
+
+You can use the following instructions to create a self-signed certificate and instruct
+the server to use it.
+
+* Create the certificate
+```
+ keytool -genkey -alias tomcat \
+ -storetype PKCS12 -keyalg RSA -keysize 2048 \
+ -keystore keystore.p12 -validity 3650
+```
+* The following environment variables will also need to be configured
+```
+KEY_STORE_PASSWORD = "password as configured in the previous step"
+spring.profiles.active = "ssl"
+```
+
 #### Deployment
 
 Deployment is handled via gradle and travis if you follow the correct git conventions.

--- a/src/main/kotlin/au/com/sealink/quickprint/AuthenticationFilter.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/AuthenticationFilter.kt
@@ -7,7 +7,7 @@ import javax.servlet.http.HttpServletResponse
 
 class AuthenticationFilter(private val apiKey: String) : OncePerRequestFilter() {
     override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain)  {
-        val apiKey = request.getHeader("api_key")
+        val apiKey = request.getHeader("x-api-key")
         if (apiKey != this.apiKey) {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid API Token")
         }

--- a/src/main/resources/application-ssl.yml
+++ b/src/main/resources/application-ssl.yml
@@ -1,0 +1,7 @@
+server:
+  port: 8443
+  ssl:
+    key-store: 'keystore.p12'
+    key-store-password: ${KEY_STORE_PASSWORD}
+    keyStoreType: 'PKCS12'
+    keyAlias: 'tomcat'

--- a/src/main/resources/application-ssl.yml
+++ b/src/main/resources/application-ssl.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8443
+  port: ${APP_PORT:8443}
   ssl:
     key-store: 'keystore.p12'
     key-store-password: ${KEY_STORE_PASSWORD}


### PR DESCRIPTION
### Why  
Makes it possible for the service to self-serve SSL (simplifies deployments in windows environments)

### Test  
Follow instructions as per the readme