### PR TITLE
Tt 4554 add logentries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 [TT-4514] - Initial port of Quickets
+[TT-4554] - Enable logentries in production mode

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,8 @@ dependencies {
 	compile "org.jetbrains.kotlin:kotlin-reflect"
     compile('com.fasterxml.jackson.module:jackson-module-kotlin')
     compile 'au.com.sealink:printing:1.3.0'
-	testCompile('org.springframework.boot:spring-boot-starter-test') {
+    compile group: 'com.rapid7', name: 'r7insight_java', version: '1.1.39'
+    testCompile('org.springframework.boot:spring-boot-starter-test') {
 		exclude module: 'junit'
 	}
     testCompile("com.nhaarman:mockito-kotlin:1.5.0")

--- a/src/main/kotlin/au/com/sealink/quickprint/RequestLoggingFilterConfig.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/RequestLoggingFilterConfig.kt
@@ -1,0 +1,18 @@
+package au.com.sealink.quickprint
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.filter.CommonsRequestLoggingFilter
+
+@Configuration
+class RequestLoggingFilterConfig {
+    @Bean
+    fun logFilter(): CommonsRequestLoggingFilter {
+        val filter = CommonsRequestLoggingFilter()
+        filter.setIncludeQueryString(true)
+        filter.setIncludePayload(true)
+        filter.setMaxPayloadLength(10000)
+        filter.setIncludeHeaders(false)
+        return filter
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <springProfile name="!production">
+        <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    </springProfile>
+
+    <springProfile name="production">
+        <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter">
+            <level value="DEBUG" />
+        </logger>
+
+        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread]) %highlight(%-5level) %logger{36}.%M - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <appender name="LE"
+                  class="com.rapid7.logback.LogentriesAppender">
+            <Token>${LOG_ENTRIES_TOKEN}</Token>
+            <Region>${LOG_ENTRIES_REGION}</Region>
+            <Debug>False</Debug>
+            <Ssl>False</Ssl>
+            <facility>USER</facility>
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <root level="info">
+            <appender-ref ref="LE" />
+        </root>
+    </springProfile>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -9,11 +9,6 @@
             <level value="DEBUG" />
         </logger>
 
-        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder>
-                <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread]) %highlight(%-5level) %logger{36}.%M - %msg%n</pattern>
-            </encoder>
-        </appender>
         <appender name="LE"
                   class="com.rapid7.logback.LogentriesAppender">
             <Token>${LOG_ENTRIES_TOKEN}</Token>


### PR DESCRIPTION
### Why  
Logs to logentries if the "production" profile is active.
It will log each request with payload data

### Test  
Enable production profile and provide logentries region "eu" and token (as per logentries website)