### PR TITLE
Tt 4558 fix json deserilisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 * [TT-4549] - Add profile to enable SSL
 * [TT-4554] - Enable logentries in production mode
 * [TT-4557] - Enable CORS support
+* [TT-4558] - Enable reading of double font sizes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # QuickPrint
 
-## Unreleased
+## 1.0.1 Unreleased
+
+* [TT-4557] - Enable CORS support
+* [TT-4558] - Enable reading of double font sizes
+* [TT-4559] - Ensure print-tickets returns a JSON response
+
+## 1.0.0
 
 * [TT-4514] - Initial port of Quickets
 * [TT-4549] - Add profile to enable SSL
 * [TT-4554] - Enable logentries in production mode
-* [TT-4557] - Enable CORS support
-* [TT-4558] - Enable reading of double font sizes

--- a/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
@@ -3,6 +3,7 @@ package au.com.sealink.quickprint
 import au.com.sealink.printing.ticket_printer.*
 import au.com.sealink.quickprint.core.PrinterRepository
 import au.com.sealink.quickprint.requests.PrintTicket
+import au.com.sealink.quickprint.requests.Response
 import au.com.sealink.quickprint.requests.toTicketElement
 import kotlinx.coroutines.experimental.async
 import org.springframework.web.bind.annotation.*
@@ -19,7 +20,7 @@ class ApplicationController(private val repository: PrinterRepository) {
     fun printers()= repository.findAll().map { it.name }
 
     @PostMapping("/print-tickets")
-    fun printTickets(@RequestBody request: PrintTicket) {
+    fun printTickets(@RequestBody request: PrintTicket) : Response {
         val printer = repository.requestPrinter(request.printerName)
         val settings = TicketPageSettings(request.pageFormat.width,
                 request.pageFormat.height,
@@ -38,5 +39,6 @@ class ApplicationController(private val repository: PrinterRepository) {
                 printer.printTickets(tickets)
             }
         }
+        return Response()
     }
 }

--- a/src/main/kotlin/au/com/sealink/quickprint/requests/Response.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/requests/Response.kt
@@ -1,0 +1,5 @@
+package au.com.sealink.quickprint.requests
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class Response(@JsonProperty("status") val status :String = "OK")

--- a/src/main/kotlin/au/com/sealink/quickprint/requests/Ticket.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/requests/Ticket.kt
@@ -9,7 +9,7 @@ data class Ticket(
     @JsonProperty("y") val y: Double,
     @JsonProperty("value") val value: String,
     @JsonProperty("key") val key: String,
-    @JsonProperty("font_size") val fontSize: Int,
+    @JsonProperty("font_size") val fontSize: Double,
     @JsonProperty("italic") val isItalic: Boolean,
     @JsonProperty("bold") val isBold: Boolean,
     @JsonProperty("orientation") val orientation: String
@@ -17,7 +17,7 @@ data class Ticket(
 
 fun Ticket.toTicketElement() : TicketElement {
     val element = TicketElement()
-    element.fontSize = this.fontSize
+    element.fontSize = this.fontSize.toInt()
     element.isBold = this.isBold
     element.isItalic = this.isItalic
     element.value = this.value


### PR DESCRIPTION
### Why  
QuickTravel allows fonts to be specified as a double, we silently convert to int in quickprint :(