### PR TITLE
Tt 4595 fix docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 - "./gradlew versionDisplay"
 - "./gradlew versionFile"
 - "export $(cat build/version.properties | xargs)"
-- "./gradlew build createEBArchive"
+- "./gradlew build buildImage buildEBArchive"
 after_success:
 - "./gradlew jacocoTestReport coveralls"
 before_cache:
@@ -22,12 +22,6 @@ cache:
 before_deploy:
   - "export ELASTIC_BEANSTALK_LABEL=$VERSION_TAG"
 deploy:
-  - provider: script
-    script: "./gradlew publishImage"
-    skip_cleanup: true
-    on:
-      all_branches: true
-      tags: true
   - provider: elasticbeanstalk
     only_create_app_version: "true"
     region: "ap-southeast-2"
@@ -39,3 +33,9 @@ deploy:
     on:
       all_branches: true
       tags: true
+  - provider: script
+    script: "./gradlew publishImage"
+    skip_cleanup: true
+    on:
+      all_branches: true
+      tags: true      

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # QuickPrint
 
+## Unreleased
+
+* [TT-4595] - Fix docker build
+
 ## 1.1.0
 
 * [TT-4522] - Add ability to generate docker image and publish to ECR

--- a/build.gradle
+++ b/build.gradle
@@ -292,7 +292,7 @@ task copyEBDirForArchiving(type: Copy) {
     into "${buildDir}/toArchive"
 }
 
-task createEBArchive(type: Zip) {
+task buildEBArchive(type: Zip) {
     dependsOn copyEBDirForArchiving
     from "${buildDir}/toArchive"
     archiveName "eb.zip"

--- a/build.gradle
+++ b/build.gradle
@@ -198,11 +198,11 @@ bintray {
     publish = true
 }
 
-def ecrRepository = '120983864185.dkr.ecr.ap-southeast-2.amazonaws.com'
+def ecrBase = '120983864185.dkr.ecr.ap-southeast-2.amazonaws.com'
 
 docker {
     registryCredentials {
-        url = "https://$ecrRepository"
+        url = "https://$ecrBase"
     }
 }
 
@@ -240,7 +240,7 @@ createDockerfile.dependsOn syncWebAppArchive
 
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 
-def ecrImageTag = "${ecrRepository}/quickprint:$war.version"
+def ecrImageTag = "${ecrBase}/quickprint:$war.version"
 task buildImage(type: DockerBuildImage) {
     dependsOn createDockerfile
     inputDir = createDockerfile.destFile.parentFile

--- a/build.gradle
+++ b/build.gradle
@@ -198,11 +198,11 @@ bintray {
     publish = true
 }
 
-def ecrRepository = 'https://120983864185.dkr.ecr.ap-southeast-2.amazonaws.com'
+def ecrRepository = '120983864185.dkr.ecr.ap-southeast-2.amazonaws.com'
 
 docker {
     registryCredentials {
-        url = ecrRepository
+        url = "https://$ecrRepository"
     }
 }
 


### PR DESCRIPTION
WHY
Tag name was invalid which caused docker to fail to build.
Move docker image creation to the build stage and not deployment