### PR TITLE
Tt 4629 disable receipt images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # QuickPrint
 
+## Unreleased
+
+* [TT-4629] - Disable images when printing receipts
+
 ## 1.2.0
 
 * [TT-4614] - Add new endpoint which supports printing receipt tickets to Epson printers

--- a/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
@@ -20,7 +20,7 @@ class ApplicationController(private val repository: PrinterRepository) {
 
     @PostMapping("/print-receipts")
     fun printReceipts(@RequestBody request: PrintReceipt) : Response {
-        val unsupportedTypes = EnumSet.of(ElementType.Barcode)
+        val unsupportedTypes = EnumSet.of(ElementType.Barcode, ElementType.Image)
         val printer = ReceiptPrinter(request.printerName)
         val tickets = request.tickets.map { it ->
             val ticket = Ticket()


### PR DESCRIPTION
WHY

the printing code provided by the library was not adequate for the epson printer in use, so disable images for now and use the inbuilt logo support instead