### PR TITLE
Tt 11531 margin x y params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [TT-7089] - Update to Spring 2.2.6 and Gradle 4.10.2
 * [TT-8218] - Update to Spring 2.3.4 and Grandle 6.7
 * [PLAT-28] - Migrate from Travis to Github Action
+* [TT-11531] - Migrated to using separate margin_x and margin_y params in PageFormat
 
 ## 1.3.1
 

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
 		compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 		compile "org.jetbrains.kotlin:kotlin-reflect"
     compile 'com.fasterxml.jackson.module:jackson-module-kotlin'
-    implementation 'au.com.sealink:printing:1.7.1'
+    implementation 'au.com.sealink:printing:1.8.0'
 
 
     compile group: 'com.rapid7', name: 'r7insight_java', version: '3.0.7'

--- a/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
@@ -46,7 +46,8 @@ class ApplicationController(private val repository: PrinterRepository) {
         val printer = repository.requestPrinter(request.printerName)
         val settings = TicketPageSettings(request.pageFormat.width,
                 request.pageFormat.height,
-                request.pageFormat.margin ?: 0.0)
+                request.pageFormat.margin_x,
+                request.pageFormat.margin_y)
 
         printer.setTicketPageSettings(settings)
 

--- a/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
@@ -46,7 +46,7 @@ class ApplicationController(private val repository: PrinterRepository) {
         val printer = repository.requestPrinter(request.printerName)
         val settings = TicketPageSettings(request.pageFormat.width,
                 request.pageFormat.height,
-                request.pageFormat.margin_x ?: request.pageFormat.margin ?: 0.0,
+                request.pageFormat.margin_x ?: 0.0,
                 request.pageFormat.margin_y ?: 0.0)
 
         printer.setTicketPageSettings(settings)

--- a/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
@@ -46,8 +46,7 @@ class ApplicationController(private val repository: PrinterRepository) {
         val printer = repository.requestPrinter(request.printerName)
         val settings = TicketPageSettings(request.pageFormat.width,
                 request.pageFormat.height,
-                request.pageFormat.margin ?: 0.0,
-                request.pageFormat.margin_x ?: 0.0,
+                request.pageFormat.margin_x ?: request.pageFormat.margin ?: 0.0,
                 request.pageFormat.margin_y ?: 0.0)
 
         printer.setTicketPageSettings(settings)

--- a/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
@@ -46,8 +46,9 @@ class ApplicationController(private val repository: PrinterRepository) {
         val printer = repository.requestPrinter(request.printerName)
         val settings = TicketPageSettings(request.pageFormat.width,
                 request.pageFormat.height,
-                request.pageFormat.margin_x,
-                request.pageFormat.margin_y)
+                request.pageFormat.margin ?: 0.0,
+                request.pageFormat.margin_x ?: 0.0,
+                request.pageFormat.margin_y ?: 0.0)
 
         printer.setTicketPageSettings(settings)
 

--- a/src/main/kotlin/au/com/sealink/quickprint/requests/PageFormat.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/requests/PageFormat.kt
@@ -1,4 +1,4 @@
 package au.com.sealink.quickprint.requests
 
 
-data class PageFormat(val width: Double, val height: Double, val margin: Double?, val margin_x: Double?, val margin_y: Double?)
+data class PageFormat(val width: Double, val height: Double, val margin_x: Double?, val margin_y: Double?)

--- a/src/main/kotlin/au/com/sealink/quickprint/requests/PageFormat.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/requests/PageFormat.kt
@@ -1,4 +1,4 @@
 package au.com.sealink.quickprint.requests
 
 
-data class PageFormat(val width: Double, val height: Double, val margin: Double?)
+data class PageFormat(val width: Double, val height: Double, val margin_x: Double, val margin_y: Double)

--- a/src/main/kotlin/au/com/sealink/quickprint/requests/PageFormat.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/requests/PageFormat.kt
@@ -1,4 +1,4 @@
 package au.com.sealink.quickprint.requests
 
 
-data class PageFormat(val width: Double, val height: Double, val margin_x: Double, val margin_y: Double)
+data class PageFormat(val width: Double, val height: Double, val margin: Double?, val margin_x: Double?, val margin_y: Double?)

--- a/src/test/kotlin/au/com/sealink/quickprint/ApplicationControllerTest.kt
+++ b/src/test/kotlin/au/com/sealink/quickprint/ApplicationControllerTest.kt
@@ -67,7 +67,7 @@ class ApplicationControllerTest(@Autowired val mockMvc: MockMvc) {
         val request = PrintTicket(
                 "TEST",
                 "printer-1",
-                PageFormat(1.0, 1.0, null),
+                PageFormat(1.0, 1.0, null, 1.3, 1.3),
                 ArrayList<ArrayList<Ticket>>()
                 )
         mockMvc.perform(post("/print-tickets")

--- a/src/test/kotlin/au/com/sealink/quickprint/ApplicationControllerTest.kt
+++ b/src/test/kotlin/au/com/sealink/quickprint/ApplicationControllerTest.kt
@@ -67,7 +67,7 @@ class ApplicationControllerTest(@Autowired val mockMvc: MockMvc) {
         val request = PrintTicket(
                 "TEST",
                 "printer-1",
-                PageFormat(1.0, 1.0, null, 1.3, 1.3),
+                PageFormat(1.0, 1.0, 1.3, 1.3),
                 ArrayList<ArrayList<Ticket>>()
                 )
         mockMvc.perform(post("/print-tickets")


### PR DESCRIPTION
**WHY**

Part of the changes to implement separate x and y margins in ticket printing.

**WHAT**

1. Updating to ticket_printers 1.8.0 in build.gradle
2. PageFormat constructor has been changed to support the separated margin_x and margin_y params
3. ApplicationController passes margin_x and margin_y from request to PageFormat