### PR TITLE
Tt 11686 update cups path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [TT-8218] - Update to Spring 2.3.4 and Grandle 6.7
 * [PLAT-28] - Migrate from Travis to Github Action
 * [TT-11531] - Migrated to using separate margin_x and margin_y params in PageFormat
+* [TT-11686] - Updated cups-pdf ppd path in docker/entrypoint.sh
 
 ## 1.3.1
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -22,6 +22,6 @@ fi
 echo CUPS is ready.
 
 echo "Check if the printer exists, add it if it doesn't"
-lpstat -v "$PRINTER_NAME" &> /dev/null || lpadmin -p "$PRINTER_NAME" -v cups-pdf:/ -E -P /usr/share/ppd/cups-pdf/CUPS-PDF.ppd
+lpstat -v "$PRINTER_NAME" &> /dev/null || lpadmin -p "$PRINTER_NAME" -v cups-pdf:/ -E -P /usr/share/ppd/cups-pdf/CUPS-PDF_opt.ppd
 
 java -jar -DQUICK_PRINT_API_KEY=$API_KEY /app/quickprint.war


### PR DESCRIPTION
**WHY**

Deploying gives the following error:

`Docker container quit unexpectedly on Tue Mar  7 01:38:38 UTC 2023:
Probing for CUPS...
CUPS is ready.
Check if the printer exists, add it if it doesn't
lpadmin: Printer drivers are deprecated and will stop working in a future version of CUPS.
lpadmin: Unable to open PPD "/usr/share/ppd/cups-pdf/CUPS-PDF.ppd": Unable to open PPD file on line 0.`

**WHAT**

This PR updates the path that that we check for the cups-pdf ppd file.