### PR TITLE
[TF-342] Add eb environment name to github action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -57,6 +57,7 @@ jobs:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           application_name: QuickPrint
+          environment_name: quickprint-pdf
           region: ap-southeast-2
           version_label: "${{ env.VERSION_TAG  }}"
           deployment_package: build/distributions/eb.zip

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -50,6 +50,13 @@ jobs:
           GITHUB_USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Publish to Github packages
+        if: startsWith(github.ref, 'refs/tags/')
+        run: ./gradlew publish
+        env:
+          GITHUB_USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Deploy to EB
         if: startsWith(github.ref, 'refs/tags/')
         uses: einaregilsson/beanstalk-deploy@v18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [TF-342] Add eb environment name to github action
+
 ## 1.5.0
 
 * [TT-5649] - Update to use non-experimental CoRoutines


### PR DESCRIPTION
Add eb environment name to github action

```environment_name: In version 10 this parameter becomes optional. If you don't pass an environment in the action will simply create the version but not deploy it anywhere.```