### PR TITLE
[TF-695] Fix nfs-mount config script

### DIFF
--- a/.ebextensions/01-nfs-mount.config
+++ b/.ebextensions/01-nfs-mount.config
@@ -15,9 +15,5 @@ commands:
       sudo sshfs -o allow_other,StrictHostKeyChecking=no,password_stdin sftp-user@172.18.0.12:/ /mnt/nfs < /tmp/credentials
       rm /tmp/credentials
 
-  05_enable_sshfs_on_boot:
-    command: |
-      echo 'sshfs#sftp-user@172.18.0.12:/ /mnt/nfs fuse.reconnect,allow_other 0 0' | sudo tee -a /etc/fstab
-
-  06_restart_docker:
-    command: service docker stop && service docker start
+  05_restart_docker:
+    command: sudo service docker restart

--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,11 @@
 *.class
 
 # Generated files
-bin/
+bin/*
 gen/
 out/
 Dockerrun.aws.json
+!bin/remount_sftp.sh
 
 # Gradle files
 .gradle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # QuickPrint
 
+## Unreleased
+
+* [TF-695] Fix nfs-mount config script
+
 ## 1.6.1
 
 * [TF-470] Update nfs mount config

--- a/bin/remount_sftp.sh
+++ b/bin/remount_sftp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Define your mount point
+MOUNT_POINT="/mnt/nfs"
+
+# Check if the mount point is already mounted
+if mountpoint -q "$MOUNT_POINT"; then
+    echo "Mount point $MOUNT_POINT is already mounted."
+else
+    echo "Mount point $MOUNT_POINT is not mounted. Mounting now..."
+    
+    SFTP_PASSWORD=$(sudo /opt/elasticbeanstalk/bin/get-config environment -k SFTP_PASSWORD)
+    echo "$SFTP_PASSWORD" > /tmp/credentials
+    sudo sshfs -o allow_other,StrictHostKeyChecking=no,password_stdin sftp-user@172.18.0.12:/ /mnt/nfs < /tmp/credentials
+    rm /tmp/credentials
+    
+    echo "Mounting complete."
+fi

--- a/bin/remount_sftp.sh
+++ b/bin/remount_sftp.sh
@@ -15,4 +15,8 @@ else
     rm /tmp/credentials
     
     echo "Mounting complete."
+
+    echo "Reboot docker now..."
+    sudo service docker restart
+    echo "Docker has been restarted."
 fi


### PR DESCRIPTION
### WHY
nfs mount script is still having issues. We need to make sure it could work when restarting service

### Acceptance Criteria
PDF printer should work automatically when the service has been restarted