### PR TITLE
Add additional logging around known spot of errors to try and gather more info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,7 @@ docker {
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile
 
 task createDockerfile(type: Dockerfile) {
-    from 'openjdk:19-jdk-buster'
+    from 'eclipse-temurin:19-jdk'
     label(
     	'maintainer': 'john.mortlock@sealink.com.au'
     )

--- a/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/ApplicationController.kt
@@ -7,6 +7,7 @@ import au.com.sealink.quickprint.requests.*
 import org.springframework.web.bind.annotation.*
 import org.springframework.http.MediaType
 import kotlinx.coroutines.*
+import java.time.LocalDateTime
 
 import java.util.*
 
@@ -22,6 +23,7 @@ class ApplicationController(private val repository: PrinterRepository) {
 
     @PostMapping("/print-receipts")
     fun printReceipts(@RequestBody request: PrintReceipt) : Response {
+        System.err.println("[${LocalDateTime.now()}] RECEIPTS: printer='${request.printerName}', tickets=${request.tickets.size}")
         val unsupportedTypes = EnumSet.of(ElementType.Barcode, ElementType.Image)
         val printer = ReceiptPrinter(request.printerName)
         val tickets = request.tickets.map {
@@ -36,7 +38,13 @@ class ApplicationController(private val repository: PrinterRepository) {
         }
 
         GlobalScope.launch {
-            printer.printTickets(tickets)
+            try {
+                printer.printTickets(tickets)
+                System.err.println("[${LocalDateTime.now()}] RECEIPTS SUCCESS: printer='${request.printerName}'")
+            } catch (e: Exception) {
+                System.err.println("[${LocalDateTime.now()}] RECEIPTS FAILED: printer='${request.printerName}', error=${e.javaClass.name}: ${e.message}")
+                e.printStackTrace()
+            }
         }
 
         return Response()
@@ -44,6 +52,7 @@ class ApplicationController(private val repository: PrinterRepository) {
 
     @PostMapping("/print-tickets")
     fun printTickets(@RequestBody request: PrintTicket) : Response {
+        System.err.println("[${LocalDateTime.now()}] TICKETS: printer='${request.printerName}', tickets=${request.tickets.size}, format=${request.pageFormat.width}x${request.pageFormat.height}")
         val printer = repository.requestPrinter(request.printerName)
         val settings = TicketPageSettings(request.pageFormat.width,
                 request.pageFormat.height,
@@ -59,7 +68,13 @@ class ApplicationController(private val repository: PrinterRepository) {
         }
 
         GlobalScope.launch {
-            printer.printTickets(tickets)
+            try {
+                printer.printTickets(tickets)
+                System.err.println("[${LocalDateTime.now()}] TICKETS SUCCESS: printer='${request.printerName}'")
+            } catch (e: Exception) {
+                System.err.println("[${LocalDateTime.now()}] TICKETS FAILED: printer='${request.printerName}', error=${e.javaClass.name}: ${e.message}")
+                e.printStackTrace()
+            }
         }
         return Response()
     }

--- a/src/main/kotlin/au/com/sealink/quickprint/core/PrintServicePrinterRepository.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/core/PrintServicePrinterRepository.kt
@@ -2,15 +2,20 @@ package au.com.sealink.quickprint.core
 
 import au.com.sealink.printing.ticketprinter.PrintServiceLocator
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 import javax.print.PrintService
 
 @Repository
 class PrintServicePrinterRepository : PrinterRepository {
     override fun requestPrinter(name: String): Printer {
+        System.err.println("[${LocalDateTime.now()}] PrinterRepository REQUEST: printer='$name'")
         return TicketPrinter(name)
     }
 
     override fun findAll(): Iterable<PrintService> {
-        return PrintServiceLocator().all.toList()
+        System.err.println("[${LocalDateTime.now()}] PrinterRepository ENUM START")
+        val services = PrintServiceLocator().all.toList()
+        System.err.println("[${LocalDateTime.now()}] PrinterRepository ENUM FOUND: count=${services.size}, names=${services.joinToString(",") { it.name }}")
+        return services
     }
 }

--- a/src/main/kotlin/au/com/sealink/quickprint/core/TicketPrinter.kt
+++ b/src/main/kotlin/au/com/sealink/quickprint/core/TicketPrinter.kt
@@ -3,19 +3,31 @@ package au.com.sealink.quickprint.core
 import au.com.sealink.printing.ticketprinter.Ticket
 import au.com.sealink.printing.ticketprinter.TicketPageSettings
 import au.com.sealink.printing.ticketprinter.TicketPrinter
+import java.time.LocalDateTime
 
 class TicketPrinter(private var name: String) : Printer {
     private val mPrinter : TicketPrinter = TicketPrinter()
 
     init {
+        System.err.println("[${LocalDateTime.now()}] TicketPrinter INIT: printer='$name'")
         mPrinter.setPrinter(this.name)
+        System.err.println("[${LocalDateTime.now()}] TicketPrinter INIT SUCCESS: printer='$name'")
     }
 
     override fun setTicketPageSettings(settings: TicketPageSettings) {
+        System.err.println("[${LocalDateTime.now()}] TicketPrinter SET_SETTINGS: printer='$name'")
         mPrinter.setTicketPageSettings(settings)
     }
 
     override fun printTickets(tickets: List<Ticket>) {
-        mPrinter.printTickets(tickets)
+        try {
+            System.err.println("[${LocalDateTime.now()}] TicketPrinter PRINT START: printer='$name', tickets=${tickets.size}, thread=${Thread.currentThread().name}")
+            mPrinter.printTickets(tickets)
+            System.err.println("[${LocalDateTime.now()}] TicketPrinter PRINT SUCCESS: printer='$name'")
+        } catch (e: Exception) {
+            System.err.println("[${LocalDateTime.now()}] TicketPrinter PRINT FAILED: printer='$name', error=${e.javaClass.name}: ${e.message}")
+            e.printStackTrace()
+            throw e
+        }
     }
 }


### PR DESCRIPTION
# WHY

The printing is still crashing out and causing issues, the current logs I don't reveal too much - possibly that the address of the printer coming back from Windows _may_ be manged and wrong, hoping that this extra logging might reveal the issue.

# WHAT

* Add simple stderr logging to diagnose JVM crashes in printing.
* Had to change the base docker image from `openjdk:19-jdk-buster` as it is not available anymore, replaced it with an equivalent image.

I haven't done Java in forever so the syntax and build config updates we're provided by Claude, thanks Claude <3.